### PR TITLE
bpo-28603 Fix tracebacks for unhashable exceptions

### DIFF
--- a/traceback2/__init__.py
+++ b/traceback2/__init__.py
@@ -438,11 +438,11 @@ class TracebackException:
         # Handle loops in __cause__ or __context__.
         if _seen is None:
             _seen = set()
-        _seen.add(exc_value)
+        _seen.add(id(exc_value))
         # Gracefully handle (the way Python 2.4 and earlier did) the case of
         # being called with no type or value (None, None, None).
         if (exc_value and getattr(exc_value, '__cause__', None) is not None
-            and exc_value.__cause__ not in _seen):
+            and id(exc_value.__cause__) not in _seen):
             cause = TracebackException(
                 type(exc_value.__cause__),
                 exc_value.__cause__,
@@ -454,7 +454,7 @@ class TracebackException:
         else:
             cause = None
         if (exc_value and getattr(exc_value, '__context__', None) is not None
-            and exc_value.__context__ not in _seen):
+            and id(exc_value.__context__) not in _seen):
             context = TracebackException(
                 type(exc_value.__context__),
                 exc_value.__context__,


### PR DESCRIPTION
TracebackException checks for loops between exceptions to prevent an
infinite traceback. It does this by putting the already-seen exception
into a set. This means that unhashable exception objects will cause an
error - an error that itself can likely not be printed because of the
presence of the unhashable exception in the chain.

In this case, we don't actually care about equality of the objects as
defined by the class designer; we want to check that we don't encounter
the self-same exception object, from a chain that is necessarily all in
memory at the same time. We can trivially do so by comparing identities
instead of equality.

An equivalent patch [was merged](https://github.com/python/cpython/pull/4014) in the CPython standard library.