### PR TITLE
Drop support for python 3.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
 install:

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ classifier =
     Programming Language :: Python :: 2.6
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.2
     Programming Language :: Python :: 3.3
     Programming Language :: Python :: 3.4
     Topic :: Software Development


### PR DESCRIPTION
Drop support for python 3.2.

It's no longer supported by pip, and tests against python 3.2 are failing
on travis.
