### PR TITLE
* make test_context_suppression less fragile

### DIFF
--- a/traceback2/tests/test_traceback.py
+++ b/traceback2/tests/test_traceback.py
@@ -420,7 +420,7 @@ class BaseExceptionReportingTests:
 Traceback (most recent call last):
   File "...traceback2/tests/test_traceback.py", line ..., in test_context_suppression
     raise_from(ZeroDivisionError, None)
-  File "<string>", line 2, in raise_from
+  File "<string>", line ..., in raise_from
 ZeroDivisionError
 """, doctest.ELLIPSIS))
 


### PR DESCRIPTION
With 1.4.0, I currently get a test failure on Python 3.6.6:

```
======================================================================
FAIL: test_context_suppression (traceback2.tests.test_traceback.PyExcReportingTests)
traceback2.tests.test_traceback.PyExcReportingTests.test_context_suppression
----------------------------------------------------------------------
testtools.testresult.real._StringException: Traceback (most recent call last):
  File "/home/ivaldi/packages/newpkg/traceback2-1.4.0/.pybuild/cpython3_3.6_traceback2/build/traceback2/tests/test_traceback.py", line 425, in test_context_suppression
    """, doctest.ELLIPSIS))
  File "/usr/lib/python3/dist-packages/testtools/testcase.py", line 498, in assertThat
    raise mismatch_error
testtools.matchers._impl.MismatchError: Expected:
    Traceback (most recent call last):
      File "...traceback2/tests/test_traceback.py", line ..., in test_context_suppression
        raise_from(ZeroDivisionError, None)
      File "<string>", line 2, in raise_from
    ZeroDivisionError
Got:
    Traceback (most recent call last):
      File "/home/ivaldi/packages/newpkg/traceback2-1.4.0/.pybuild/cpython3_3.6_traceback2/build/traceback2/tests/test_traceback.py", line 414, in test_context_suppression
        raise_from(ZeroDivisionError, None)
      File "<string>", line 3, in raise_from
    ZeroDivisionError

```

This appears to be triggered by an off-by-one line difference.  Ellipsizing the affected line number allows the test to pass.